### PR TITLE
add include option and change default argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,60 @@
-## Ika
+# Ika
 [![Gem Version](https://badge.fury.io/rb/ika.svg)](http://badge.fury.io/rb/ika)
+
+Ika implements the function that export/import ActiveModel data with json.
+
+## Installation
+
+In Rails, add it to your Gemfile:
+
+```ruby
+gem 'ika'
+```
+
+## Usage
+
+In case: `Group` has many tags and `User` belongs to multiple groups with `GroupUsers` such as below.
+
+```ruby
+class User < ActiveRecord::Base
+  has_many :group_users
+  has_many :groups, through: :group_users
+end
+
+class GroupUsers < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :group
+end
+
+class Group < ActiveRecord::Base
+  has_many :group_users
+  has_many :users, through: :group_users
+  has_many :tags
+end
+
+class Tag < ActiveRecord::Base
+  belongs_to :group
+end
+```
+
+Now you can export with `export` method on your model or relation.
+
+```ruby
+require 'json'
+# with no options
+
+JSON.parse User.export
+# => [{"id":1,"name":"iruca3"},{"id":2,"name":"inkling"}]
+JSON.parse User.where(id: 1).export
+# => [{"id":1,"name":"iruca3"}]
+JSON.parse User.find(id: 2).export
+# => {"id":2,"name":"inkling"}
+
+# with include option
+JSON.parse User.export(include: :groups)
+# => [{"id":1,"name":"iruca3","groups":[{"id":1,"name":"aqutras"},{"id":2,"name":"Splatoon"}]},{"id":2,"name":"inkling","groups":[{"id":2,"name":"Splatoon"}]}]
+JSON.parse User.find(id: 1).export(include: [{groups: [:tags]}])
+# => {"id":1,"name":"iruca3","groups":[{"id":1,"name":"aqutras","tags":[{"id":1,"name":"Company"}]},{"id":2,"name":"Splatoon","tags":[{"id":2,"name":"Game"},{"id":3,"name":"Inkling"}]}]}
+```
 
 This project rocks and uses MIT-LICENSE.

--- a/lib/ika.rb
+++ b/lib/ika.rb
@@ -1,14 +1,70 @@
 module Ika
   extend ActiveSupport::Concern
 
-  def export(options = self.class.reflections.keys)
-    to_json(include: options)
+  class ::Hash
+    def max_depth
+      max_depth = 1
+      depth_func = ->(hsh, cur_depth) do
+        max_depth = cur_depth if cur_depth > max_depth
+        hsh["children"].to_a.each{|h| depth_func.call(h, cur_depth+1)}
+        max_depth
+      end
+      depth_func.call(self, 0)
+    end
   end
 
   module ClassMethods
-    def export(options = reflections.keys)
-      includes(options).to_json(include: options)
+    def export(options = {}, objects = nil)
+      all_symbol = true
+      options[:include] ||= []
+      options[:include] = [options[:include]] unless options[:include].is_a?(Array)
+      objects = self.includes(options[:include]) unless objects
+      options[:include].each do |opt|
+        all_symbol = false unless opt.is_a?(Symbol)
+      end
+
+      return objects.to_json(include: options[:include]) if all_symbol
+
+      whole_obj_arr = []
+      objects.each do |object|
+        obj_arr = {}
+        options[:include].each do |relation|
+          if relation.is_a?(::Hash)
+            relation.keys.each do |property|
+              obj_arr[property] = JSON.parse(object.try(property).export({include: relation[property]}, object.try(property)))
+            end
+          elsif relation.is_a?(Symbol)
+            obj_arr[relation] = JSON.parse(object.try(:relation).to_json(include: relation))
+          end
+        end
+        whole_obj_arr.push(obj_arr)
+      end
+      JSON.generate(whole_obj_arr)
     end
+  end
+
+  def export(options = {}, object = nil)
+    objects ||= self
+    all_symbol = true
+    options[:include] ||= []
+    options[:include] = [options[:include]] unless options[:include].is_a?(Array)
+    options[:include].each do |opt|
+      all_symbol = false unless opt.is_a?(Symbol)
+    end
+
+    return objects.to_json(include: options[:include]) if all_symbol
+
+    obj_hash = JSON.parse objects.to_json
+    options[:include].each do |relation|
+      if relation.is_a?(::Hash)
+        relation.keys.each do |property|
+          obj_hash[property] = JSON.parse(objects.try(property).includes(relation[property]).export({include: relation[property]}, objects.try(property)))
+        end
+      elsif relation.is_a?(Symbol)
+        obj_hash[relation] = JSON.parse(objects.try(relation).to_json)
+      end
+    end
+    JSON.generate(obj_hash)
   end
 end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe User, type: :model do
           ]
         }
       ]
-      expect(User.export).to match_json_expression(ret)
+      expect(User.export(include: [:group_users, :groups])).to match_json_expression(ret)
     end
 
     it 'get only self' do
@@ -46,7 +46,7 @@ RSpec.describe User, type: :model do
           'updated_at' => JSON.parse(user.to_json)['updated_at']
         }
       ]
-      expect(User.export(nil)).to match_json_expression(ret)
+      expect(User.export).to match_json_expression(ret)
     end
 
     it 'get selected relation' do
@@ -68,7 +68,7 @@ RSpec.describe User, type: :model do
           ]
         }
       ]
-      expect(User.export(:group_users)).to match_json_expression(ret)
+      expect(User.export(include: :group_users)).to match_json_expression(ret)
     end
   end
 
@@ -100,7 +100,7 @@ RSpec.describe User, type: :model do
         ]
       }
 
-      expect(User.first.export).to match_json_expression(ret)
+      expect(User.first.export(include: [:group_users, :groups])).to match_json_expression(ret)
     end
 
     it 'get only self' do
@@ -111,7 +111,7 @@ RSpec.describe User, type: :model do
         'created_at' => JSON.parse(user.to_json)['created_at'],
         'updated_at' => JSON.parse(user.to_json)['updated_at']
       }
-      expect(User.first.export(nil)).to match_json_expression(ret)
+      expect(User.first.export).to match_json_expression(ret)
     end
 
     it 'get selected relation' do
@@ -131,7 +131,7 @@ RSpec.describe User, type: :model do
           }
         ]
       }
-      expect(User.first.export(:group_users)).to match_json_expression(ret)
+      expect(User.first.export(include: :group_users)).to match_json_expression(ret)
     end
   end
 end


### PR DESCRIPTION
### Change argument

Argument receives options with hash object. The key of `include` means what relations should include to the json. This option can do nested relations as well. Currently only `include` option is available.

### Change default exportation

Default argument means that any relations should include to the json.