### PR TITLE
using oj / fix symbols

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     ika (1.0.12)
       activerecord (>= 4.0)
+      oj
 
 GEM
   remote: https://rubygems.org/
@@ -85,6 +86,7 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
+    oj (3.3.5)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)

--- a/ika.gemspec
+++ b/ika.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   s.add_dependency 'activerecord', '>= 4.0'
+  s.add_dependency 'oj'
 
   s.add_development_dependency 'rails', '>= 5.1'
   s.add_development_dependency 'sqlite3', '~> 1.0'


### PR DESCRIPTION
I tested only export on the rspec by `binding.pry`. test code and result is below.
It seems about 10% faster.

## before
[1] pry(#<RSpec::ExampleGroups::User::Export_2>)> start_time = Time.now; 10000.times { User.ika_export }; end_time = Time.now;
[2] pry(#<RSpec::ExampleGroups::User::Export_2>)> end_time - start_time
=> 6.913517
[3] pry(#<RSpec::ExampleGroups::User::Export_2>)> start_time = Time.now; 10000.times { User.ika_export }; end_time = Time.now;
[4] pry(#<RSpec::ExampleGroups::User::Export_2>)> end_time - start_time
=> 7.455534

## after
[1] pry(#<RSpec::ExampleGroups::User::Export_2>)> start_time = Time.now; 10000.times { User.ika_export }; end_time = Time.now;
[2] pry(#<RSpec::ExampleGroups::User::Export_2>)> end_time - start_time
=> 6.451766
[3] pry(#<RSpec::ExampleGroups::User::Export_2>)> start_time = Time.now; 10000.times { User.ika_export }; end_time = Time.now;
[4] pry(#<RSpec::ExampleGroups::User::Export_2>)> end_time - start_time
=> 6.421231

